### PR TITLE
Add comment for service account authentication step in terragon-setup.sh

### DIFF
--- a/terragon-setup.sh
+++ b/terragon-setup.sh
@@ -432,6 +432,7 @@ if [ "$CRITICAL_FAILURE" = true ]; then
 else
     # Authenticate with service account
     echo -e "\n${YELLOW}Authenticating with service account...${NC}"
+    # 2. Authenticate with service account
     if $GCLOUD_CMD auth activate-service-account --key-file="$SERVICE_ACCOUNT_KEY_FILE" --quiet 2>/dev/null; then
         echo -e "${GREEN}✅ Service account authentication successful${NC}"
 


### PR DESCRIPTION
## Summary
- Adds a clarifying comment before the service account authentication command in `terragon-setup.sh`

## Changes

### Script Update
- Inserted a comment `# 2. Authenticate with service account` above the `gcloud auth activate-service-account` command to improve script readability and clarity

## Test plan
- Verified that the script runs without errors after adding the comment
- Confirmed the comment accurately describes the authentication step

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/5811dcc0-15f7-4a20-a3ac-4b05516911ac